### PR TITLE
Potential fix for code scanning alert no. 4: Log entries created from user input

### DIFF
--- a/Services/Sarah.Logging/Logger.cs
+++ b/Services/Sarah.Logging/Logger.cs
@@ -132,8 +132,7 @@ namespace Sarah.Logging
                 }
             }
         }
-    }
-
+    
         /// <summary>
         /// Sanitizes a log message by removing or replacing newlines and other problematic characters.
         /// Prevents log forging.
@@ -148,4 +147,5 @@ namespace Sarah.Logging
             // You may want to remove other control chars as needed
             return msg.Replace("\r", "").Replace("\n", "");
         }
+    }
 }

--- a/Services/Sarah.Logging/Logger.cs
+++ b/Services/Sarah.Logging/Logger.cs
@@ -88,7 +88,9 @@ namespace Sarah.Logging
         /// <param name="msg"></param>
         public void Log(ErrorLevel level, string msg)
         {
-            _lastLog.Enqueue(msg);
+            // Sanitize the message to avoid log forging
+            var sanitizedMsg = SanitizeLogMessage(msg);
+            _lastLog.Enqueue(sanitizedMsg);
             if (_lastLog.Count > MAX_LASTLOG_SIZE)
             {
                 _lastLog.TryDequeue(out string _);
@@ -96,8 +98,8 @@ namespace Sarah.Logging
 
             if (_logger == null)
             {
-                Console.WriteLine(msg);
-                Debug.WriteLine(msg);
+                Console.WriteLine(sanitizedMsg);
+                Debug.WriteLine(sanitizedMsg);
             }
             else
             {
@@ -108,27 +110,42 @@ namespace Sarah.Logging
                         if (this.LogDebugAsInfo)
                         {
                             /* Debug als Info loggen in Docker */
-                            _logger.LogInformation(msg);
+                            _logger.LogInformation(sanitizedMsg);
                         }
                         else
                         {
-                            _logger.LogDebug(msg);
+                            _logger.LogDebug(sanitizedMsg);
                         }
                         break;
                     case ErrorLevel.Info:
-                        _logger.LogInformation(msg);
+                        _logger.LogInformation(sanitizedMsg);
                         break;
                     case ErrorLevel.Warning:
-                        _logger.LogWarning(msg);
+                        _logger.LogWarning(sanitizedMsg);
                         break;
                     case ErrorLevel.Error:
-                        _logger.LogError(msg);
+                        _logger.LogError(sanitizedMsg);
                         break;
                     case ErrorLevel.Exception:
-                        _logger.LogError(msg);
+                        _logger.LogError(sanitizedMsg);
                         break;
                 }
             }
         }
     }
+
+        /// <summary>
+        /// Sanitizes a log message by removing or replacing newlines and other problematic characters.
+        /// Prevents log forging.
+        /// </summary>
+        /// <param name="msg"></param>
+        /// <returns></returns>
+        private string SanitizeLogMessage(string msg)
+        {
+            if (msg == null)
+                return string.Empty;
+            // Remove \r and \n to prevent log forging
+            // You may want to remove other control chars as needed
+            return msg.Replace("\r", "").Replace("\n", "");
+        }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/fondencn/sarah/security/code-scanning/4](https://github.com/fondencn/sarah/security/code-scanning/4)

To fix the issue, we should sanitize all user-supplied data before it is logged. Specifically, before writing any string to logs, any input that could include user-provided data must be sanitized to remove or encode problematic characters (newlines, control chars, etc.) that could lead to log forging or confusion.

**Best implementation plan:**
- Add a helper method (e.g., `SanitizeLogMessage(string msg)`) in `Logger.cs` to sanitize log messages by removing or replacing all newline (`\r`, `\n`) and possibly other control characters.
- Call this method on all `msg` inputs before any use in the logging sinks (`_logger.LogInformation(...)`, `_logger.LogWarning(...)`, etc.), and also before enqueuing in the internal log queue or writing to console/debug.
- Ensure that it is only applied once (i.e., not double-sanitizing the same string on each method call chain).
- Only update the code in `Services/Sarah.Logging/Logger.cs`, as that is the single choke point for logging.

Required:
- A new private method (e.g., `SanitizeLogMessage(string msg)`) in Logger.
- Change `Log(...)` to sanitize `msg` before using it.
- Use the sanitized message everywhere in the method (`_lastLog.Enqueue`, console/Debug, and `_logger` calls).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
