### PR TITLE
Make speech service great again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,6 +397,7 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 Sarah.Server/appsettings.secrets.json
+Microservices/Sarah.SpeechServer.WebApi/appsettings.secrets.json
 sarah.client/src/environments/environment.prod.ts
 sarah.client/src/environments/environment.ts
 sarah.client/.env
@@ -404,3 +405,4 @@ docker-compos.secrets.yml
 
 # Environment variables with secrets
 .env
+Microservices/Sarah.SpeechServer.WebApi/SpeechCache/*

--- a/Libs/Sarah.Voice/Recognition/AzureSpeechRecognizer.cs
+++ b/Libs/Sarah.Voice/Recognition/AzureSpeechRecognizer.cs
@@ -22,12 +22,16 @@ namespace Sarah.Voice.Recognition
             _LEDService = ledService;
             _Configuration = configuration;
             _logger = logger;
+
+            var subscriptionKey = _Configuration["AzureSpeech:SubscriptionKey"] ?? throw new ArgumentException("AzureSpeech:SubscriptionKey is not configured");
+            var region = _Configuration["AzureSpeech:Region"] ?? throw new ArgumentException("AzureSpeech:Region is not configured");
+            var language = _Configuration["AzureSpeech:Language"] ?? "de-DE";
             // Creates an instance of a speech config with specified subscription key and service region.
             // Replace with your own subscription key and service region (e.g., "westus").
             // The default language is "en-us".
-            _config = SpeechConfig.FromSubscription(_Configuration["AzureSpeech:SubscriptionKey"], _Configuration["AzureSpeech:Region"]);
-            _config.SpeechRecognitionLanguage = "de-DE";
-            _config.SpeechSynthesisLanguage = "de-DE";
+            _config = SpeechConfig.FromSubscription(subscriptionKey, region);
+            _config.SpeechRecognitionLanguage = language;
+            _config.SpeechSynthesisLanguage = language;
             _config.EnableAudioLogging();
         }
 

--- a/Libs/Sarah.Voice/Recognition/AzureSpeechRecognizer.cs
+++ b/Libs/Sarah.Voice/Recognition/AzureSpeechRecognizer.cs
@@ -23,8 +23,8 @@ namespace Sarah.Voice.Recognition
             _Configuration = configuration;
             _logger = logger;
 
-            var subscriptionKey = _Configuration["AzureSpeech:SubscriptionKey"] ?? throw new ArgumentException("AzureSpeech:SubscriptionKey is not configured");
-            var region = _Configuration["AzureSpeech:Region"] ?? throw new ArgumentException("AzureSpeech:Region is not configured");
+            var subscriptionKey = _Configuration["AzureSpeech:SubscriptionKey"] ?? throw new InvalidOperationException("AzureSpeech:SubscriptionKey is not configured");
+            var region = _Configuration["AzureSpeech:Region"] ?? throw new InvalidOperationException("AzureSpeech:Region is not configured");
             var language = _Configuration["AzureSpeech:Language"] ?? "de-DE";
             // Creates an instance of a speech config with specified subscription key and service region.
             // Replace with your own subscription key and service region (e.g., "westus").

--- a/Libs/Sarah.Voice/Synthesis/AzureSpeechSynthesizer.cs
+++ b/Libs/Sarah.Voice/Synthesis/AzureSpeechSynthesizer.cs
@@ -32,13 +32,19 @@ namespace Sarah.Voice.Synthesis
             _Configuration = configuration;
             _logger = logger;
 
+
+            var subscriptionKey = _Configuration["AzureSpeech:SubscriptionKey"] ?? throw new ArgumentException("AzureSpeech:SubscriptionKey is not configured");
+            var region = _Configuration["AzureSpeech:Region"] ?? throw new ArgumentException("AzureSpeech:Region is not configured");
+            var language = _Configuration["AzureSpeech:Language"] ?? "de-DE";
+            var voiceName = _Configuration["AzureSpeech:VoiceName"] ?? "de-DE-KatjaNeural";
+
             // Creates an instance of a speech config with specified subscription key and service region.
             // Replace with your own subscription key and service region (e.g., "westus").
             // The default language is "en-us".
-            _config = SpeechConfig.FromSubscription(_Configuration["Speech:SubscriptionKey"], _Configuration["Speech:Region"]);
+            _config = SpeechConfig.FromSubscription(subscriptionKey, region);
             //config.SpeechRecognitionLanguage = "de-DE";
-            _config.SpeechSynthesisLanguage = "de-DE";
-            _config.SpeechSynthesisVoiceName = "de-DE-KatjaNeural";
+            _config.SpeechSynthesisLanguage = language;
+            _config.SpeechSynthesisVoiceName = voiceName;
             // _config.SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.Audio16Khz128KBitRateMonoMp3);
 
 

--- a/Microservices/Sarah.SpeechServer.WebApi/LedServiceFactory.cs
+++ b/Microservices/Sarah.SpeechServer.WebApi/LedServiceFactory.cs
@@ -1,4 +1,3 @@
-using Sarah.API.Interfaces;
 using Sarah.API.Interfaces.Service;
 using Sarah.LEDService;
 

--- a/Microservices/Sarah.SpeechServer.WebApi/LedServiceFactory.cs
+++ b/Microservices/Sarah.SpeechServer.WebApi/LedServiceFactory.cs
@@ -1,0 +1,24 @@
+using Sarah.API.Interfaces;
+using Sarah.API.Interfaces.Service;
+using Sarah.LEDService;
+
+namespace Sarah.SpeechServer;
+
+public static class LedServiceFactory
+{
+    public static ILEDService CreateLedService(IServiceProvider provider)
+    {
+        var logger = provider.GetRequiredService<ILogger<ReSpeakerLEDService>>();
+
+        try
+        {
+            return new ReSpeakerLEDService(logger);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to initialize ReSpeakerLEDService. Falling back to EmptyLEDService.");
+            logger.LogInformation("If you are running on a ReSpeaker device, please ensure that the necessary hardware and drivers are properly set up.");
+            return new EmptyLEDService();
+        }
+    }
+}

--- a/Microservices/Sarah.SpeechServer.WebApi/Program.cs
+++ b/Microservices/Sarah.SpeechServer.WebApi/Program.cs
@@ -47,9 +47,14 @@ builder.Services.AddHostedService<SpeechEventSubscriber>();
 
 var app = builder.Build();
 
-app.UseSwagger();
-app.UseSwaggerUI();
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+    app.MapOpenApi();
+}
+
+app.UseServiceDefaults();
 app.MapControllers();
 app.UseSpeechService(app.Configuration);
 

--- a/Microservices/Sarah.SpeechServer.WebApi/Program.cs
+++ b/Microservices/Sarah.SpeechServer.WebApi/Program.cs
@@ -1,6 +1,5 @@
 using Sarah.API.Interfaces;
 using Sarah.API.Interfaces.Service;
-using Sarah.LEDService;
 using Sarah.SpeechServer;
 using Sarah.SpeechServer.Extensions;
 using Sarah.Voice;
@@ -24,7 +23,8 @@ builder.Configuration
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 
-builder.Services.AddSingleton<ILEDService, ReSpeakerLEDService>();
+builder.Services.AddSingleton<ILEDService>(provider => LedServiceFactory.CreateLedService(provider));
+
 builder.Services.AddHttpClient<IDeviceService, DeviceServiceClient>(client =>
 {
     var deviceServiceUrl = builder.Configuration["services__deviceservice__http__0"]
@@ -54,4 +54,3 @@ app.MapControllers();
 app.UseSpeechService(app.Configuration);
 
 app.Run();
-

--- a/Microservices/Sarah.SpeechServer.WebApi/appsettings.Development.json
+++ b/Microservices/Sarah.SpeechServer.WebApi/appsettings.Development.json
@@ -8,6 +8,12 @@
   },
   "AllowedHosts": "*",
   "Location": "Arbeitszimmer",
+  "RabbitMQ": {
+    "HostName": "rabbitmq",
+    "Port": 5672,
+    "UserName": "guest",
+    "Password": "guest"
+  },
   "DeviceServiceUrl": "https+http://deviceservice",
   "AzureSpeech": {
     "Region": "westeurope",

--- a/Microservices/Sarah.SpeechServer.WebApi/appsettings.Development.json
+++ b/Microservices/Sarah.SpeechServer.WebApi/appsettings.Development.json
@@ -6,5 +6,12 @@
       "Microsoft.EntityFrameworkCore.Database.Command": "Debug"
     }
   },
-  "DeviceServiceUrl": "https+http://deviceservice"
+  "AllowedHosts": "*",
+  "Location": "Arbeitszimmer",
+  "DeviceServiceUrl": "https+http://deviceservice",
+  "AzureSpeech": {
+    "Region": "westeurope",
+    "Language": "de-DE",
+    "VoiceName": "de-DE-KatjaNeural"
+  }
 }

--- a/Microservices/Sarah.SpeechServer.WebApi/appsettings.json
+++ b/Microservices/Sarah.SpeechServer.WebApi/appsettings.json
@@ -7,6 +7,12 @@
   },
   "AllowedHosts": "*",
   "Location": "Arbeitszimmer",
+  "RabbitMQ": {
+    "HostName": "rabbitmq",
+    "Port": 5672,
+    "UserName": "guest",
+    "Password": "guest"
+  },
   "DeviceServiceUrl": "https+http://deviceservice",
   "AzureSpeech": {
     "Region": "westeurope",

--- a/Microservices/Sarah.SpeechServer.WebApi/appsettings.json
+++ b/Microservices/Sarah.SpeechServer.WebApi/appsettings.json
@@ -7,5 +7,10 @@
   },
   "AllowedHosts": "*",
   "Location": "Arbeitszimmer",
-  "DeviceServiceUrl": "https+http://deviceservice"
+  "DeviceServiceUrl": "https+http://deviceservice",
+  "AzureSpeech": {
+    "Region": "westeurope",
+    "Language": "de-DE",
+    "VoiceName": "de-DE-KatjaNeural"
+  }
 }


### PR DESCRIPTION
- [x] Add `app.UseServiceDefaults()` to the SpeechServer request pipeline before `MapControllers()`
- [x] Guard `UseSwagger()`, `UseSwaggerUI()`, and `MapOpenApi()` behind `app.Environment.IsDevelopment()` check
- [x] Update `AzureSpeechRecognizer.cs` in `Libs/Sarah.Voice/Recognition/`

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
