### PR TITLE
feat: Enhance dashboard to support DoorSensor with status and duratio…

### DIFF
--- a/Microservices/Sarah.Dashboard.WebApi/Services/DashboardService.cs
+++ b/Microservices/Sarah.Dashboard.WebApi/Services/DashboardService.cs
@@ -213,6 +213,8 @@ public class DashboardService : IDashboardService
             KnownDeviceTypes.FibaroHeatController
                 or KnownDeviceTypes.AeotecThermostat
                 or KnownDeviceTypes.ShellyTrv => "Heizung",
+            KnownDeviceTypes.AeotecDoorSensor 
+                or KnownDeviceTypes.FibaroDoorWindowSensor2=> "DoorSensor",
             _ => sourceDevice.TypeName
         };
     }

--- a/Microservices/Sarah.DeviceService.WebApi/Controllers/DevicesController.cs
+++ b/Microservices/Sarah.DeviceService.WebApi/Controllers/DevicesController.cs
@@ -426,6 +426,14 @@ public class DevicesController : ControllerBase
             if (networkItem is IBatterySensor batterySensor && batterySensor.Battery != null)
                 props.Add(new ExtendedPropertyDto { Key = "Battery", Value = batterySensor.Battery.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) });
         }
+        else if (networkItem is IDoorSensor doorSensor)
+        {
+            props.Add(new ExtendedPropertyDto { Key = "IsOpen", Value = (doorSensor.State == DoorSensorState.Offen).ToString() });
+            if (doorSensor.LastOpenDuration.HasValue)
+                props.Add(new ExtendedPropertyDto { Key = "LastOpenDurationMinutes", Value = doorSensor.LastOpenDuration.Value.TotalMinutes.ToString("F1", System.Globalization.CultureInfo.InvariantCulture) });
+            if (doorSensor.LastStateChanged.HasValue)
+                props.Add(new ExtendedPropertyDto { Key = "LastStateChanged", Value = doorSensor.LastStateChanged.Value.ToString("o") });
+        }
         return props;
     }
 

--- a/sarah.client/src/app/home/home.component.html
+++ b/sarah.client/src/app/home/home.component.html
@@ -100,6 +100,16 @@
                           (temperatureSet)="setThermostatTemperatureValue($event.itemId, $event.temperature)"
                         ></app-thermostat-dial>
                       </ng-container>
+                      <ng-container *ngSwitchCase="'DoorSensor'">
+                        <div class="mt-1">
+                          <span class="badge" [ngClass]="item.doorIsOpen ? 'bg-danger' : 'bg-success'">
+                            {{ item.doorIsOpen ? 'Open' : 'Closed' }}
+                          </span>
+                          <span *ngIf="item.doorIsOpen && item.doorLastOpenDurationMinutes !== null" class="ms-2 small text-white-50">
+                            for {{ item.doorLastOpenDurationMinutes | number:'1.0-1' }} min
+                          </span>
+                        </div>
+                      </ng-container>
                       <ng-container *ngSwitchDefault>
                         <div class="row">
                           &nbsp;
@@ -120,6 +130,9 @@
                       </ng-container>
                       <ng-container *ngSwitchCase="'Heizung'">
                         <span style="font-size: 2.5rem;" [title]="item.subType">🌡️</span>
+                      </ng-container>
+                      <ng-container *ngSwitchCase="'DoorSensor'">
+                        <span style="font-size: 2.5rem;" [title]="item.subType">🚪</span>
                       </ng-container>
                       <ng-container *ngSwitchDefault>
                         <div class="row">

--- a/sarah.client/src/app/home/home.component.ts
+++ b/sarah.client/src/app/home/home.component.ts
@@ -427,4 +427,20 @@ export class DashboardItemViewModel {
     const n = Number(val);
     return Number.isFinite(n) ? n : null;
   }
+
+  get doorIsOpen(): boolean {
+    return this.item.extendedProperties?.find(x => x.key === 'IsOpen')?.value === 'True';
+  }
+
+  get doorLastOpenDurationMinutes(): number | null {
+    const val = this.item.extendedProperties?.find(x => x.key === 'LastOpenDurationMinutes')?.value;
+    if (val === undefined || val === null || val === '') return null;
+    const n = Number(val);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  get doorLastStateChanged(): string | null {
+    const val = this.item.extendedProperties?.find(x => x.key === 'LastStateChanged')?.value;
+    return val && val.trim().length > 0 ? val : null;
+  }
 }


### PR DESCRIPTION
This pull request adds support for displaying door sensor devices in the dashboard. It introduces backend changes to expose door sensor state and metadata, and frontend changes to visualize the door sensor status and duration. The most important changes are grouped below:

**Backend: Door Sensor Support**

* Added mapping for `AeotecDoorSensor` and `FibaroDoorWindowSensor2` device types to the new `"DoorSensor"` category in `DashboardService.cs` to enable identification and handling in the dashboard.
* Extended `BuildExtendedProperties` in `DevicesController.cs` to include `IsOpen`, `LastOpenDurationMinutes`, and `LastStateChanged` properties for devices implementing `IDoorSensor`.

**Frontend: Door Sensor Visualization**

* Added new getters (`doorIsOpen`, `doorLastOpenDurationMinutes`, `doorLastStateChanged`) in `DashboardItemViewModel` to extract door sensor properties from device data.
* Updated `home.component.html` to display a badge showing whether the door is open or closed, and the duration if open, for devices of type `"DoorSensor"`.
* Added a door icon (🚪) for `"DoorSensor"` devices in the dashboard UI.…n display