### PR TITLE
Refactor temperature handling and fix average calculation

### DIFF
--- a/Microservices/Sarah.DeviceService.WebApi/Controllers/DevicesController.cs
+++ b/Microservices/Sarah.DeviceService.WebApi/Controllers/DevicesController.cs
@@ -552,14 +552,14 @@ public class DevicesController : ControllerBase
             var temps = devices
                 .Select(d => _deviceService.GetNetworkItem(d.NodeID))
                 .OfType<ITemperatureSensor>()
-                .Where(s => s.Temperature != null)
+                .Where(s => s.Temperature != null && s.Temperature.Value != 0) // Filter out invalid 0 values
                 .Select(s => s.Temperature.Value)
                 .ToList();
 
             if (!temps.Any())
                 return NoContent();
 
-            return Ok(temps.Average());
+            return Ok(CalculateAverageRoomTemperature(temps));
         }
         catch (Exception ex)
         {

--- a/Microservices/Sarah.Monitoring.WebApi/Services/Monitors/DoorMonitor.cs
+++ b/Microservices/Sarah.Monitoring.WebApi/Services/Monitors/DoorMonitor.cs
@@ -240,6 +240,7 @@ namespace Sarah.Monitoring.Monitors
 
         private class SurveillanceTask
         {
+            private const float DEFAULT_OFF_TEMPERATURE = 12.0f;
             private readonly RabbitMQClient _rabbitMQ;
             private readonly IReadOnlyDictionary<byte, HeatingInfo> _heatingInfo;
             private readonly DoorMonitor _doorMonitor;
@@ -456,13 +457,13 @@ namespace Sarah.Monitoring.Monitors
                                             if (heatingDevice?.Thermostat?.TemperatureSetpoint is float setpoint)
                                             {
                                                 /* 12° bedeutet "aus" - nur ausschalten wenn nicht sowieso schon aus! */
-                                                if (setpoint != 12.0f)
+                                                if (setpoint != DEFAULT_OFF_TEMPERATURE)
                                                 {
                                                     this.OriginalHeatingTemperatures.Add(new KeyValuePair<byte, float>(heatingId, setpoint));
 
                                                     /* Heizung ohne await damit die Sprachausgabe sofort kommt
                                                      * Könnte zum Problem bei mehreren Heizungen werden (ZWave-RaceCondition!) */
-                                                    _ = _deviceServiceClient.SetThermostatTemperatureAsync(heatingDevice.Id, 12.0f);
+                                                    _ = _deviceServiceClient.SetThermostatTemperatureAsync(heatingDevice.Id, DEFAULT_OFF_TEMPERATURE);
                                                 }
                                             }
                                             else


### PR DESCRIPTION
Replace magic number for default off temperature with a constant and exclude invalid temperature readings of 0 from the average calculation.