### PR TITLE
fix: fix dashboard position saving - use ExecuteSqlAsync batch update…

### DIFF
--- a/Microservices/Sarah.Dashboard.WebApi/Services/DashboardService.cs
+++ b/Microservices/Sarah.Dashboard.WebApi/Services/DashboardService.cs
@@ -130,38 +130,46 @@ public class DashboardService : IDashboardService
             return true;
         }
 
-        var entities = await _repository.GetAllAsync();
-        var entityMap = entities.ToDictionary(e => e.Id);
         var orderedIdsSet = reorderDto.OrderedIds.ToHashSet();
 
-        // Validate that the request contains each dashboard item exactly once.
-        if (reorderDto.OrderedIds.Count != entityMap.Count || orderedIdsSet.Count != reorderDto.OrderedIds.Count)
+        // Validate no duplicates in the provided list
+        if (orderedIdsSet.Count != reorderDto.OrderedIds.Count)
+        {
+            return false;
+        }
+
+        // Validate that the request contains every dashboard item exactly once.
+        var totalCount = await _context.DashboardItems.CountAsync();
+        if (reorderDto.OrderedIds.Count != totalCount)
         {
             return false;
         }
 
         // Validate that all provided IDs exist
+        var existingIds = await _context.DashboardItems
+            .Select(e => e.Id)
+            .ToListAsync();
+
         foreach (var id in reorderDto.OrderedIds)
         {
-            if (!entityMap.ContainsKey(id))
+            if (!existingIds.Contains(id))
             {
                 return false;
             }
         }
 
-        // Assign new positions in-memory, then persist once atomically
-        using var transaction = await _context.Database.BeginTransactionAsync();
+        // Persist new positions in a single batch UPDATE using PostgreSQL unnest
+        var orderedIds = reorderDto.OrderedIds.ToArray();
+        var updatedAt = DateTime.UtcNow;
 
-        for (int i = 0; i < reorderDto.OrderedIds.Count; i++)
-        {
-            var entity = entityMap[reorderDto.OrderedIds[i]];
-            entity.Position = i;
-            entity.UpdatedAt = DateTime.UtcNow;
-            _context.DashboardItems.Update(entity);
-        }
-
-        await _context.SaveChangesAsync();
-        await transaction.CommitAsync();
+        await _context.Database.ExecuteSqlAsync(
+            $"""
+            UPDATE "DashboardItems"
+            SET "Position" = CAST(t."idx" AS integer) - 1,
+                "UpdatedAt" = {updatedAt}
+            FROM unnest({orderedIds}) WITH ORDINALITY AS t("id", "idx")
+            WHERE "Id" = CAST(t."id" AS integer)
+            """);
 
         _logger.LogInformation("Reordered {Count} dashboard items", reorderDto.OrderedIds.Count);
         return true;

--- a/sarah.client/package-lock.json
+++ b/sarah.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sarah.client",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sarah.client",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "@angular/animations": "^18.2.1",
         "@angular/cdk": "^18.2.14",

--- a/sarah.client/src/app/home/home.component.ts
+++ b/sarah.client/src/app/home/home.component.ts
@@ -205,6 +205,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       next: () => {
         this.logger.debug('Dashboard order saved');
         this.isEditMode = false;
+        this.updateDashboardItems();
       },
       error: (error) => {
         this.logger.error('Error saving dashboard order:', error);


### PR DESCRIPTION
This pull request introduces improvements to the dashboard item reordering logic in the backend and updates the client version. The backend changes focus on making the reordering process more efficient and robust by validating input more thoroughly and using a batch database update. The frontend now refreshes the dashboard items after a successful reorder.

**Backend: Dashboard reordering improvements**
- Refactored the `ReorderDashboardItemsAsync` method in `DashboardService.cs` to:
  - Validate that the provided IDs have no duplicates and match the total count of dashboard items in the database.
  - Check that all provided IDs exist in the database, improving data integrity.
  - Replace the per-item update and transaction with a single batch `UPDATE` using PostgreSQL's `unnest`, improving performance and atomicity.

**Frontend: User experience improvement**
- After successfully saving the new dashboard order, the dashboard items are now refreshed in the `HomeComponent` to reflect the changes immediately.

**Other updates**
- Updated the client package version from `0.0.1` to `1.0.0` in `package-lock.json`, indicating a major release.… and reload after save

Agent-Logs-Url: https://github.com/fondencn/sarah/sessions/7dcd195c-340c-48a5-817d-63cc27dbaad5