### PR TITLE
Include device name in event processing and prompt generation

### DIFF
--- a/Microservices/Sarah.Rules.WebApi/Services/Kernel/SmartHomeKernelService.cs
+++ b/Microservices/Sarah.Rules.WebApi/Services/Kernel/SmartHomeKernelService.cs
@@ -39,10 +39,10 @@ public sealed class SmartHomeKernelService
         _options = options.Value;
     }
 
-    public async Task ProcessEventAsync(NetworkEvent evt, CancellationToken cancellationToken = default)
+    public async Task ProcessEventAsync(NetworkEvent evt, string? deviceName = null, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Processing network event: {EventType} from node {NodeId} (property: {Property})",
-            evt.GetType().Name, evt.SourceNodeId, evt.Property);
+        _logger.LogInformation("Processing network event: {EventType} from node {NodeId} (property: {Property}, deviceName: {DeviceName})",
+            evt.GetType().Name, evt.SourceNodeId, evt.Property, deviceName ?? "unknown");
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
@@ -51,7 +51,7 @@ public sealed class SmartHomeKernelService
 
         Microsoft.SemanticKernel.Kernel kernel = BuildKernel(scope.ServiceProvider);
         var chatService = kernel.GetRequiredService<IChatCompletionService>();
-        ChatHistory chatHistory = await BuildChatHistoryAsync(db, evt, cancellationToken);
+        ChatHistory chatHistory = await BuildChatHistoryAsync(db, evt, deviceName, cancellationToken);
 
         var settings = new OpenAIPromptExecutionSettings
         {
@@ -69,7 +69,7 @@ public sealed class SmartHomeKernelService
         _logger.LogDebug("LLM response received (role: {Role}, length: {Length})",
             response.Role.Label, response.Content?.Length ?? 0);
 
-        await PersistConversationTurnAsync(db, AuthorRole.User.Label, BuildEventPrompt(evt), cancellationToken);
+        await PersistConversationTurnAsync(db, AuthorRole.User.Label, BuildEventPrompt(evt, deviceName), cancellationToken);
 
         if (!string.IsNullOrWhiteSpace(response.Content))
         {
@@ -177,7 +177,7 @@ public sealed class SmartHomeKernelService
             .Take(_options.MaxHistoryMessages);
     }
 
-    internal string BuildEventPrompt(NetworkEvent evt)
+    internal string BuildEventPrompt(NetworkEvent evt, string? deviceName = null)
     {
         string payload = JsonSerializer.Serialize(evt, evt.GetType(), new JsonSerializerOptions
         {
@@ -189,6 +189,8 @@ public sealed class SmartHomeKernelService
         sb.AppendLine($"EventType: {evt.GetType().Name}");
         sb.AppendLine($"Property: {evt.Property}");
         sb.AppendLine($"SourceNodeId: {evt.SourceNodeId}");
+        if (!string.IsNullOrWhiteSpace(deviceName))
+            sb.AppendLine($"DeviceName: {deviceName}");
         sb.AppendLine($"CreationDate: {evt.CreationDate:O}");
         sb.AppendLine("Payload:");
         sb.AppendLine(payload);
@@ -258,7 +260,7 @@ public sealed class SmartHomeKernelService
         }
     }
 
-    private async Task<ChatHistory> BuildChatHistoryAsync(ApplicationDbContext db, NetworkEvent evt, CancellationToken cancellationToken)
+    private async Task<ChatHistory> BuildChatHistoryAsync(ApplicationDbContext db, NetworkEvent evt, string? deviceName, CancellationToken cancellationToken)
     {
         var history = new ChatHistory();
         history.AddSystemMessage(_promptProvider.BuildSystemPrompt());
@@ -271,7 +273,7 @@ public sealed class SmartHomeKernelService
             history.AddMessage(ParseRole(message.Role), message.Content);
         }
 
-        history.AddUserMessage(BuildEventPrompt(evt));
+        history.AddUserMessage(BuildEventPrompt(evt, deviceName));
         return history;
     }
 

--- a/Microservices/Sarah.Rules.WebApi/Services/RuleService.cs
+++ b/Microservices/Sarah.Rules.WebApi/Services/RuleService.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Sarah.Rules.WebApi.Data;
 using Sarah.Rules.WebApi.Data.Entities;
 using Sarah.Rules.Services.Kernel;
+using Sarah.ServiceClients;
 
 namespace Sarah.Rules
 {
@@ -623,9 +624,25 @@ namespace Sarah.Rules
         /// </summary>
         public async Task EvaluateRules(NetworkEvent e)
         {
+            string? deviceName = null;
+            if (e.SourceNodeId > 0)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var deviceClient = scope.ServiceProvider.GetRequiredService<DeviceServiceClient>();
+                    var device = await deviceClient.GetDeviceByNodeIdAsync(e.SourceNodeId);
+                    deviceName = device?.Name;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not resolve device name for node {NodeId}", e.SourceNodeId);
+                }
+            }
+
             try
             {
-                await _smartHomeKernel.ProcessEventAsync(e);
+                await _smartHomeKernel.ProcessEventAsync(e, deviceName);
                 await WriteExecutionLogAsync($"SemanticKernel:{e.GetType().Name}", success: true);
             }
             catch (Exception ex)
@@ -716,9 +733,25 @@ namespace Sarah.Rules
         /// </summary>
         /// <param name="e"></param>
         /// <returns></returns>
-        public Task Notify(NetworkEvent e)
+        public async Task Notify(NetworkEvent e)
         {
-            return _smartHomeKernel.ProcessEventAsync(e);
+            string? deviceName = null;
+            if (e.SourceNodeId > 0)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var deviceClient = scope.ServiceProvider.GetRequiredService<DeviceServiceClient>();
+                    var device = await deviceClient.GetDeviceByNodeIdAsync(e.SourceNodeId);
+                    deviceName = device?.Name;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not resolve device name for node {NodeId} in Notify", e.SourceNodeId);
+                }
+            }
+
+            await _smartHomeKernel.ProcessEventAsync(e, deviceName);
         }
 
         /// <summary>

--- a/Microservices/Sarah.Rules.WebApi/Services/RuleService.cs
+++ b/Microservices/Sarah.Rules.WebApi/Services/RuleService.cs
@@ -735,8 +735,15 @@ namespace Sarah.Rules
         /// <returns></returns>
         public async Task Notify(NetworkEvent e)
         {
-            string? deviceName = null;
-            if (e.SourceNodeId > 0)
+            string? deviceName = e switch
+            {
+                DoorOrWindowOpenedEvent x => x.DeviceName,
+                DoorOrWindowStillOpenEvent x => x.DeviceName,
+                DoorOrWindowClosedEvent x => x.DeviceName,
+                _ => null
+            };
+
+            if (string.IsNullOrWhiteSpace(deviceName) && e.SourceNodeId > 0)
             {
                 try
                 {

--- a/tests/Sarah.Rules.Tests/SmartHomeKernelServiceBuildEventPromptTests.cs
+++ b/tests/Sarah.Rules.Tests/SmartHomeKernelServiceBuildEventPromptTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sarah.API.BusinessObjects;
+using Sarah.Rules.Services.Kernel;
+
+namespace Sarah.Rules.Tests;
+
+public class SmartHomeKernelServiceBuildEventPromptTests
+{
+    [Fact]
+    public void BuildEventPrompt_WithoutDeviceName_DoesNotContainDeviceNameLine()
+    {
+        var service = CreateService();
+        var evt = new ClickedEvent(5, 1);
+
+        string prompt = service.BuildEventPrompt(evt);
+
+        Assert.DoesNotContain("DeviceName:", prompt);
+        Assert.Contains("SourceNodeId: 5", prompt);
+    }
+
+    [Fact]
+    public void BuildEventPrompt_WithDeviceName_ContainsDeviceNameLine()
+    {
+        var service = CreateService();
+        var evt = new ClickedEvent(5, 1);
+
+        string prompt = service.BuildEventPrompt(evt, deviceName: "Wohnzimmer Schalter");
+
+        Assert.Contains("DeviceName: Wohnzimmer Schalter", prompt);
+        Assert.Contains("SourceNodeId: 5", prompt);
+    }
+
+    [Fact]
+    public void BuildEventPrompt_DeviceNameAppearsAfterSourceNodeId()
+    {
+        var service = CreateService();
+        var evt = new ClickedEvent(7, 2);
+
+        string prompt = service.BuildEventPrompt(evt, deviceName: "Küche Sensor");
+
+        int nodeIdIndex = prompt.IndexOf("SourceNodeId:", StringComparison.Ordinal);
+        int deviceNameIndex = prompt.IndexOf("DeviceName:", StringComparison.Ordinal);
+
+        Assert.True(nodeIdIndex >= 0 && deviceNameIndex >= 0, "Both lines must be present");
+        Assert.True(deviceNameIndex > nodeIdIndex, "DeviceName line must appear after SourceNodeId line");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildEventPrompt_NullOrWhitespaceDeviceName_DoesNotContainDeviceNameLine(string? deviceName)
+    {
+        var service = CreateService();
+        var evt = new ClickedEvent(3, 0);
+
+        string prompt = service.BuildEventPrompt(evt, deviceName);
+
+        Assert.DoesNotContain("DeviceName:", prompt);
+    }
+
+    private static SmartHomeKernelService CreateService()
+    {
+        var options = Options.Create(new SemanticKernelOptions
+        {
+            ConversationRetentionHours = 24,
+            MaxHistoryMessages = 50
+        });
+
+        return new SmartHomeKernelService(
+            scopeFactory: null!,
+            options: options,
+            promptProvider: null!,
+            logger: NullLogger<SmartHomeKernelService>.Instance);
+    }
+}


### PR DESCRIPTION
Enhance event processing by including the device name in logs and prompts. This change improves context for events and allows for better tracking and debugging. Additionally, tests ensure the correct behavior of the prompt generation with and without the device name.