### PR TITLE
Refactor AlarmScheduleService to singleton with hosted lifecycle management

### DIFF
--- a/Microservices/Sarah.Rules.WebApi/Program.cs
+++ b/Microservices/Sarah.Rules.WebApi/Program.cs
@@ -132,7 +132,8 @@ builder.Services.AddSingleton<Sarah.Rules.Services.MessageBasedGridStateProvider
 builder.Services.AddSingleton<Sarah.API.Interfaces.IGridStateProvider>(sp => sp.GetRequiredService<Sarah.Rules.Services.MessageBasedGridStateProvider>());
 
 // Register schedule services
-builder.Services.AddScoped<Sarah.Rules.Services.AlarmScheduleService>();
+builder.Services.AddSingleton<Sarah.Rules.Services.AlarmScheduleService>();
+builder.Services.AddHostedService<Sarah.Rules.Services.AlarmScheduleHostedService>();
 
 // Add services to the container.
 builder.Services.AddControllers();
@@ -215,12 +216,5 @@ await promptProvider.ReloadAsync();
 var promptRuleStore = app.Services.GetRequiredService<SmartHomePromptRuleStore>();
 promptRuleStore.ReloadFromProvider();
 ruleSvc.RegisterRuleStore(promptRuleStore);
-
-// Initialize AlarmScheduleService
-using (var scope = app.Services.CreateScope())
-{
-    var alarmService = scope.ServiceProvider.GetRequiredService<Sarah.Rules.Services.AlarmScheduleService>();
-    await alarmService.Start();
-}
 
 app.Run();

--- a/Microservices/Sarah.Rules.WebApi/Services/AlarmScheduleHostedService.cs
+++ b/Microservices/Sarah.Rules.WebApi/Services/AlarmScheduleHostedService.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Sarah.Rules.Services;
+
+/// <summary>
+/// Hosts AlarmScheduleService in the ASP.NET Core hosted lifecycle.
+/// </summary>
+public sealed class AlarmScheduleHostedService : IHostedService
+{
+    private readonly AlarmScheduleService _alarmScheduleService;
+
+    public AlarmScheduleHostedService(AlarmScheduleService alarmScheduleService)
+    {
+        _alarmScheduleService = alarmScheduleService;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await _alarmScheduleService.Start();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _alarmScheduleService.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/Microservices/Sarah.Rules.WebApi/Services/AlarmScheduleService.cs
+++ b/Microservices/Sarah.Rules.WebApi/Services/AlarmScheduleService.cs
@@ -68,7 +68,7 @@ public class AlarmScheduleService : IDisposable
                 // Every 12 hours check for alarms needing cleanup
                 while (!_updateCancellationTokenSource.Token.IsCancellationRequested)
                 {
-                    await Task.Delay(12 * 60 * 1000, _updateCancellationTokenSource.Token);
+                    await Task.Delay(12 * 60 * 60 * 1000, _updateCancellationTokenSource.Token);
                     await CleanupOldAlarms();
                 }
             }
@@ -565,6 +565,7 @@ public class AlarmScheduleService : IDisposable
         _updateCancellationTokenSource?.Dispose();
         _updateCancellationTokenSource = null;
         _updateTask = null;
+        _reloadLock.Dispose();
     }
 
     private sealed class ScheduledAlarm : IDisposable

--- a/Microservices/Sarah.Rules.WebApi/Services/AlarmScheduleService.cs
+++ b/Microservices/Sarah.Rules.WebApi/Services/AlarmScheduleService.cs
@@ -21,24 +21,22 @@ namespace Sarah.Rules.Services;
 public class AlarmScheduleService : IDisposable
 {
     private static readonly JsonSerializerOptions JsonOptions = CreateJsonOptions();
-    private readonly ApplicationDbContext _db;
     private readonly ILogger<AlarmScheduleService> _logger;
     private readonly RabbitMQClient _rabbitMQ;
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly AlarmExecutionOptions _executionOptions;
     private readonly SemaphoreSlim _reloadLock = new(1, 1);
     private readonly ConcurrentDictionary<long, ScheduledAlarm> _scheduledAlarms = new();
+    private int _isDisposed;
     private CancellationTokenSource? _updateCancellationTokenSource;
     private Task? _updateTask;
 
     public AlarmScheduleService(
-        ApplicationDbContext db,
         ILogger<AlarmScheduleService> logger,
         RabbitMQClient rabbitMQ,
         IServiceScopeFactory serviceScopeFactory,
         IOptions<AlarmExecutionOptions> executionOptions)
     {
-        _db = db;
         _logger = logger;
         _rabbitMQ = rabbitMQ;
         _serviceScopeFactory = serviceScopeFactory;
@@ -50,21 +48,33 @@ public class AlarmScheduleService : IDisposable
     /// </summary>
     public Task Start()
     {
+        if (Volatile.Read(ref _isDisposed) == 1 || _updateCancellationTokenSource != null)
+        {
+            return Task.CompletedTask;
+        }
+
         _logger.LogDebug("AlarmScheduleService gestartet.");
 
         _updateCancellationTokenSource = new CancellationTokenSource();
         _ = RefreshSchedulesAsync();
         _updateTask = Task.Run(async () =>
         {
-            // Initial delay, then clean up old alarms
-            await Task.Delay(10 * 1000);
-            await CleanupOldAlarms();
-
-            // Every 12 hours check for alarms needing cleanup
-            while (!_updateCancellationTokenSource.Token.IsCancellationRequested)
+            try
             {
-                await Task.Delay(12 * 60 * 1000);
+                // Initial delay, then clean up old alarms
+                await Task.Delay(10 * 1000, _updateCancellationTokenSource.Token);
                 await CleanupOldAlarms();
+
+                // Every 12 hours check for alarms needing cleanup
+                while (!_updateCancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    await Task.Delay(12 * 60 * 1000, _updateCancellationTokenSource.Token);
+                    await CleanupOldAlarms();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected during shutdown.
             }
         }, _updateCancellationTokenSource.Token);
 
@@ -109,9 +119,22 @@ public class AlarmScheduleService : IDisposable
 
     private async Task RefreshSchedulesAsync()
     {
-        await _reloadLock.WaitAsync();
+        if (Volatile.Read(ref _isDisposed) == 1)
+        {
+            return;
+        }
+
+        var lockAcquired = false;
         try
         {
+            await _reloadLock.WaitAsync();
+            lockAcquired = true;
+
+            if (Volatile.Read(ref _isDisposed) == 1)
+            {
+                return;
+            }
+
             foreach (var scheduled in _scheduledAlarms.Values)
             {
                 scheduled.Dispose();
@@ -119,7 +142,10 @@ public class AlarmScheduleService : IDisposable
 
             _scheduledAlarms.Clear();
 
-            var alarms = await _db.AlarmSchedules
+            using var scope = _serviceScopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var alarms = await db.AlarmSchedules
                 .Where(a => a.IsActive)
                 .OrderBy(a => a.AlarmTime)
                 .ToListAsync();
@@ -131,9 +157,23 @@ public class AlarmScheduleService : IDisposable
 
             _logger.LogDebug("Loaded {Count} active alarms into the scheduler", alarms.Count);
         }
+        catch (ObjectDisposedException)
+        {
+            // Can happen during shutdown races; ignore.
+        }
         finally
         {
-            _reloadLock.Release();
+            if (lockAcquired)
+            {
+                try
+                {
+                    _reloadLock.Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Ignore shutdown races.
+                }
+            }
         }
     }
 
@@ -166,6 +206,11 @@ public class AlarmScheduleService : IDisposable
 
     private async Task HandleAlarmFiredAsync(long alarmId)
     {
+        if (Volatile.Read(ref _isDisposed) == 1)
+        {
+            return;
+        }
+
         try
         {
             using var scope = _serviceScopeFactory.CreateScope();
@@ -200,8 +245,25 @@ public class AlarmScheduleService : IDisposable
         }
         finally
         {
-            await RefreshSchedulesAsync();
+            if (Volatile.Read(ref _isDisposed) == 0)
+            {
+                await RefreshSchedulesAsync();
+            }
         }
+    }
+
+    private async Task<TResult> WithDbContextAsync<TResult>(Func<ApplicationDbContext, Task<TResult>> action)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return await action(db);
+    }
+
+    private async Task WithDbContextAsync(Func<ApplicationDbContext, Task> action)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await action(db);
     }
 
     private bool ShouldSuppressTemperatureAlarm(AlarmScheduleEntity alarm)
@@ -309,9 +371,10 @@ public class AlarmScheduleService : IDisposable
     /// </summary>
     public async Task<IEnumerable<AlarmScheduleEntity>> GetActiveAlarmsAsync()
     {
-        return await _db.AlarmSchedules
-            .Where(a => a.IsActive)
-            .ToListAsync();
+        return await WithDbContextAsync(db =>
+            db.AlarmSchedules
+                .Where(a => a.IsActive)
+                .ToListAsync());
     }
 
     /// <summary>
@@ -319,7 +382,7 @@ public class AlarmScheduleService : IDisposable
     /// </summary>
     public async Task<AlarmScheduleEntity?> GetAlarmByIdAsync(long id)
     {
-        return await _db.AlarmSchedules.FindAsync(id);
+        return await WithDbContextAsync(db => db.AlarmSchedules.FindAsync(id).AsTask());
     }
 
     /// <summary>
@@ -327,7 +390,7 @@ public class AlarmScheduleService : IDisposable
     /// </summary>
     public async Task<IEnumerable<AlarmScheduleEntity>> GetAllAlarmsAsync()
     {
-        return await _db.AlarmSchedules.ToListAsync();
+        return await WithDbContextAsync(db => db.AlarmSchedules.ToListAsync());
     }
 
     private static string SanitizeForLog(string? value)
@@ -346,8 +409,11 @@ public class AlarmScheduleService : IDisposable
         if (alarm == null)
             throw new ArgumentNullException(nameof(alarm));
 
-        _db.AlarmSchedules.Add(alarm);
-        await _db.SaveChangesAsync();
+        await WithDbContextAsync(async db =>
+        {
+            db.AlarmSchedules.Add(alarm);
+            await db.SaveChangesAsync();
+        });
 
         var safeAlarmText = SanitizeForLog(alarm.GetDisplayText());
 
@@ -373,7 +439,7 @@ public class AlarmScheduleService : IDisposable
     /// </summary>
     public async Task<AlarmScheduleEntity> UpdateAlarmAsync(long id, AlarmScheduleEntity alarm)
     {
-        var existing = await _db.AlarmSchedules.FindAsync(id);
+        var existing = await WithDbContextAsync(db => db.AlarmSchedules.FindAsync(id).AsTask());
         if (existing == null)
             throw new KeyNotFoundException($"Alarm mit ID {id} nicht gefunden");
 
@@ -393,8 +459,11 @@ public class AlarmScheduleService : IDisposable
         existing.HasRecurrence = alarm.HasRecurrence;
         existing.SerializedRecurrence = alarm.SerializedRecurrence;
 
-        _db.AlarmSchedules.Update(existing);
-        await _db.SaveChangesAsync();
+        await WithDbContextAsync(async db =>
+        {
+            db.AlarmSchedules.Update(existing);
+            await db.SaveChangesAsync();
+        });
         _logger.LogInformation("Alarm aktualisiert: {AlarmId}", id);
         
         // Notify subscribers of the change
@@ -414,12 +483,15 @@ public class AlarmScheduleService : IDisposable
     /// </summary>
     public async Task DeleteAlarmAsync(long id)
     {
-        var alarm = await _db.AlarmSchedules.FindAsync(id);
+        var alarm = await WithDbContextAsync(db => db.AlarmSchedules.FindAsync(id).AsTask());
         if (alarm == null)
             throw new KeyNotFoundException($"Alarm mit ID {id} nicht gefunden");
 
-        _db.AlarmSchedules.Remove(alarm);
-        await _db.SaveChangesAsync();
+        await WithDbContextAsync(async db =>
+        {
+            db.AlarmSchedules.Remove(alarm);
+            await db.SaveChangesAsync();
+        });
         _logger.LogInformation("Alarm gelöscht: {AlarmId}", id);
         
         // Notify subscribers of the change
@@ -437,13 +509,16 @@ public class AlarmScheduleService : IDisposable
     /// </summary>
     public async Task<AlarmScheduleEntity> ToggleAlarmActiveAsync(long id)
     {
-        var alarm = await _db.AlarmSchedules.FindAsync(id);
+        var alarm = await WithDbContextAsync(db => db.AlarmSchedules.FindAsync(id).AsTask());
         if (alarm == null)
             throw new KeyNotFoundException($"Alarm mit ID {id} nicht gefunden");
 
         alarm.IsActive = !alarm.IsActive;
-        _db.AlarmSchedules.Update(alarm);
-        await _db.SaveChangesAsync();
+        await WithDbContextAsync(async db =>
+        {
+            db.AlarmSchedules.Update(alarm);
+            await db.SaveChangesAsync();
+        });
         _logger.LogInformation("Alarm-Status gewechselt: {AlarmId}, IsActive: {IsActive}", id, alarm.IsActive);
         
         // Notify subscribers of the change
@@ -460,14 +535,19 @@ public class AlarmScheduleService : IDisposable
 
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 1)
+        {
+            return;
+        }
+
+        _updateCancellationTokenSource?.Cancel();
+
         foreach (var scheduled in _scheduledAlarms.Values)
         {
             scheduled.Dispose();
         }
 
         _scheduledAlarms.Clear();
-
-        _updateCancellationTokenSource?.Cancel();
         
         // Wait for the background task to complete before disposing
         if (_updateTask != null)
@@ -483,7 +563,8 @@ public class AlarmScheduleService : IDisposable
         }
         
         _updateCancellationTokenSource?.Dispose();
-        _reloadLock.Dispose();
+        _updateCancellationTokenSource = null;
+        _updateTask = null;
     }
 
     private sealed class ScheduledAlarm : IDisposable

--- a/tests/Sarah.Rules.Tests/AlarmScheduleHostedServiceTests.cs
+++ b/tests/Sarah.Rules.Tests/AlarmScheduleHostedServiceTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sarah.Rules.Services;
+using Sarah.Rules.WebApi.Data;
+using Sarah.Rules.WebApi.Options;
+
+namespace Sarah.Rules.Tests;
+
+public class AlarmScheduleHostedServiceTests
+{
+    [Fact]
+    public async Task StartAsync_ThenStopAsync_DoesNotThrow()
+    {
+        using var provider = BuildServiceProvider();
+
+        var scheduler = new AlarmScheduleService(
+            logger: NullLogger<AlarmScheduleService>.Instance,
+            rabbitMQ: null!,
+            serviceScopeFactory: provider.GetRequiredService<IServiceScopeFactory>(),
+            executionOptions: Options.Create(new AlarmExecutionOptions()));
+
+        var hostedService = new AlarmScheduleHostedService(scheduler);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_IsIdempotent_WhenCalledMultipleTimes()
+    {
+        using var provider = BuildServiceProvider();
+
+        var scheduler = new AlarmScheduleService(
+            logger: NullLogger<AlarmScheduleService>.Instance,
+            rabbitMQ: null!,
+            serviceScopeFactory: provider.GetRequiredService<IServiceScopeFactory>(),
+            executionOptions: Options.Create(new AlarmExecutionOptions()));
+
+        var hostedService = new AlarmScheduleHostedService(scheduler);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await hostedService.StopAsync(CancellationToken.None);
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Sarah.Rules.Tests/AlarmScheduleServiceLifetimeTests.cs
+++ b/tests/Sarah.Rules.Tests/AlarmScheduleServiceLifetimeTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sarah.Rules.Data.Entities;
+using Sarah.Rules.Services;
+using Sarah.Rules.WebApi.Data;
+using Sarah.Rules.WebApi.Options;
+
+namespace Sarah.Rules.Tests;
+
+public class AlarmScheduleServiceLifetimeTests
+{
+    [Fact]
+    public async Task RefreshSchedulesAsync_AfterDispose_DoesNotThrow()
+    {
+        using var provider = BuildServiceProvider();
+        var service = CreateService(provider);
+
+        service.Dispose();
+
+        var refreshMethod = typeof(AlarmScheduleService).GetMethod(
+            "RefreshSchedulesAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(refreshMethod);
+
+        var refreshTask = (Task?)refreshMethod!.Invoke(service, null);
+        Assert.NotNull(refreshTask);
+
+        await refreshTask!;
+    }
+
+    [Fact]
+    public async Task GetActiveAlarmsAsync_ReturnsOnlyActiveRows_WhenServiceIsSingletonStyle()
+    {
+        using var provider = BuildServiceProvider();
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.AlarmSchedules.AddRange(
+                new AlarmScheduleEntity
+                {
+                    AlarmTime = DateTime.UtcNow.AddMinutes(5),
+                    Text = "active",
+                    IsActive = true
+                },
+                new AlarmScheduleEntity
+                {
+                    AlarmTime = DateTime.UtcNow.AddMinutes(10),
+                    Text = "inactive",
+                    IsActive = false
+                });
+
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(provider);
+        var active = (await service.GetActiveAlarmsAsync()).ToList();
+
+        Assert.Single(active);
+        Assert.Equal("active", active[0].Text);
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        var databaseRoot = new InMemoryDatabaseRoot();
+        var services = new ServiceCollection();
+        services.AddSingleton(databaseRoot);
+        services.AddDbContext<ApplicationDbContext>((sp, options) =>
+            options.UseInMemoryDatabase("alarm-schedule-service-lifetime-tests", sp.GetRequiredService<InMemoryDatabaseRoot>()));
+        return services.BuildServiceProvider();
+    }
+
+    private static AlarmScheduleService CreateService(IServiceProvider provider)
+    {
+        return new AlarmScheduleService(
+            logger: NullLogger<AlarmScheduleService>.Instance,
+            rabbitMQ: null!,
+            serviceScopeFactory: provider.GetRequiredService<IServiceScopeFactory>(),
+            executionOptions: Options.Create(new AlarmExecutionOptions()));
+    }
+}


### PR DESCRIPTION
Convert AlarmScheduleService to a singleton and implement a hosted service for better lifecycle management. This change enhances the service's integration within the ASP.NET Core environment. Additionally, tests ensure the new implementation functions correctly without throwing exceptions during start and stop operations.